### PR TITLE
Case-fold named and system colors

### DIFF
--- a/js/32-colors.js
+++ b/js/32-colors.js
@@ -117,11 +117,11 @@ walkDeclarations(ast, ({property, value}) => {
 	}
 
 	for (let match of value.matchAll(keywordRegex)) {
-		incrementByKey(usage.keywords, match[0]);
+		incrementByKey(usage.keywords, match[0].toLowerCase());
 	}
 
 	for (let match of value.matchAll(systemRegex)) {
-		incrementByKey(usage.system, match[0]);
+		incrementByKey(usage.system, system.find(kw => kw.toLowerCase() == match[0].toLowerCase()));
 	}
 
 	for (let match of value.matchAll(/\b(?<!\-)(?:currentColor|transparent)\b/gi)) {


### PR DESCRIPTION
Prevent duplicate named colors like RED, red, Red, etc. Normalize all system colors to the casing in the source array.

Progress on #32